### PR TITLE
Use r-reticulate environment by default

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,5 +1,6 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^changelog$
 ^coverage$
 ^palantir.Rcheck$
 ^palantir.*\.tar\.gz$

--- a/R/install.R
+++ b/R/install.R
@@ -30,7 +30,7 @@ pypalantir <- NULL
 install_palantir <- function(
   version = "0.4.0",
   python_version = "3.9",
-  envname = "r-palantir",
+  envname = "r-reticulate",
   restart_session = TRUE,
   recreate_environment = FALSE
 ) {

--- a/changelog/@unreleased/pr-5.v2.yml
+++ b/changelog/@unreleased/pr-5.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Use r-reticulate environment by default
+  links:
+  - https://github.com/palantir/palantir-r-sdk/pull/5

--- a/man/install_palantir.Rd
+++ b/man/install_palantir.Rd
@@ -7,7 +7,7 @@
 install_palantir(
   version = "0.4.0",
   python_version = "3.9",
-  envname = "r-palantir",
+  envname = "r-reticulate",
   restart_session = TRUE,
   recreate_environment = FALSE
 )


### PR DESCRIPTION
By default, this is the conda environment used by reticulate, so this reduces the risk reticulates looks for the package in the wrong conda environent.