### PR TITLE
Check for conda instead of python in install_palantir

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -36,9 +36,9 @@ install_palantir <- function(
 ) {
   packages <- c(paste0("palantir-sdk==", version), "numpy", "pandas", "pyarrow")
 
-  # check for anaconda installation
-  if (!reticulate::py_available(initialize = TRUE)) {
-    stop("Python is not installed or not in system path.")
+  # check for conda installation
+  if (is.null(reticulate::conda_binary())) {
+    stop("Conda is not available, please run `reticulate::install_miniconda()` to install it.")
   }
 
   if (envname %in% reticulate::conda_list()$name && recreate_environment) {


### PR DESCRIPTION
Reticulate initializes itself with root python rather than conda when `reticulate::py_available(initialize = TRUE)` is called.