### PR TITLE
Add troubleshooting steps for reticulate

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -79,7 +79,7 @@ install_palantir <- function(
     },
 
     on_error = function(error) {
-      stop(paste("Use palantir::install_palantir() to install palantir", error$message))
+      stop(paste("Use palantir::install_palantir() to install palantir\n", error$message))
     }
   ))
   invisible(NULL)

--- a/README.md
+++ b/README.md
@@ -49,3 +49,17 @@ write_table(df, "/Path/to/dataset")
 ```R
 upload_file(file.path("~", "Downloads", "example"), "/Path/to/dataset")
 ```
+
+## Troubleshooting
+You may run into the following error, in particular after restarting your session:
+```
+ Error in on_error(result) : 
+  Use palantir::install_palantir() to install palantir ModuleNotFoundError: No module named 'palantir'
+```
+This indicates `reticulate` is not set up to use the right version of python.
+You can set it with the environment variable `RETICULATE_PYTHON`.
+By default, `palantir::install_palantir()` will install the python module in the default conda environment
+so you can add the following to your `.Rprofile`:
+```
+Sys.setenv(RETICULATE_PYTHON = reticulate::conda_python())
+```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ upload_file(file.path("~", "Downloads", "example"), "/Path/to/dataset")
 You may run into the following error, in particular after restarting your session:
 ```
  Error in on_error(result) : 
-  Use palantir::install_palantir() to install palantir ModuleNotFoundError: No module named 'palantir'
+  Use palantir::install_palantir() to install palantir
+  ModuleNotFoundError: No module named 'palantir'
 ```
 This indicates `reticulate` is not set up to use the right version of python.
 You can set it with the environment variable `RETICULATE_PYTHON`.


### PR DESCRIPTION
Some users can have overrides causing reticulate to import the `palantir` python module from another environment than the one where `palantir::install_palantir()` installs it. Clarifying in the README how to require reticulate to use the location where we install palantir-sdk by default