### PR TITLE
Use arrow for read_table and write_table

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: palantir
 Title: Interface to Palantir
-Version: 0.0.1
+Version: 0.1.1
 Authors@R:
     c(person(given = "Alexandre",
              family = "Guinaudeau",
@@ -17,14 +17,15 @@ RoxygenNote: 7.1.1
 Depends: 
     R (>= 3.5.0)
 Imports:
+    arrow (>= 0.14.0),
     reticulate (>= 1.12)
 Suggests:
-    arrow (>= 0.14.0),
     dplyr,
     lintr,
     testthat (>= 3.0.0),
     rstudioapi,
     withr
 Collate: 
+    'schema.R'
     'datasets.R'
     'install.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: palantir
 Title: Interface to Palantir
-Version: 0.1.1
+Version: 0.2.0
 Authors@R:
     c(person(given = "Alexandre",
              family = "Guinaudeau",

--- a/R/schema.R
+++ b/R/schema.R
@@ -1,0 +1,56 @@
+#  (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+#' @keywords internal
+ARROW_TO_FOUNDRY_FIELDS <- c( # nolint
+  int8 = "byte",
+  int16 = "short",
+  int32 = "integer",
+  int64 = "long",
+  float16 = "float",
+  halffloat = "float",
+  float32 = "float",
+  float = "float",
+  float64 = "double",
+  double = "double",
+  boolean = "boolean",
+  bool = "boolean",
+  utf8 = "string",
+  large_utf8 = "string",
+  string = "string",
+  binary = "binary",
+  large_binary = "binary",
+  date32 = "date",
+  timestamp = "timestamp"
+)
+
+#' @keywords internal
+arrow_to_foundry_schema <- function(arrow_data) {
+  pypalantir$datasets$types$FoundrySchema(
+    fields = lapply(arrow_data$schema, get_field)
+  )
+}
+
+#' @keywords internal
+get_field <- function(field) {
+  foundry_type <- ARROW_TO_FOUNDRY_FIELDS[field$type$name]
+  if (is.na(foundry_type)) {
+    stop("Unsupported column type: ", field$type$name)
+  }
+  pypalantir$datasets$types$Field(
+    name = field$name,
+    field_type = foundry_type,
+    nullable = field$nullable
+  )
+}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This SDK is incubating and subject to change.
 Install the library from Github:
 ```R
 install.packages("remotes")
-remotes::install_github("https://github.com/palantir/palantir-r-sdk", ref = "0.1.1")
+remotes::install_github("https://github.com/palantir/palantir-r-sdk", ref = "0.2.0")
 ```
 
 This library relies on [palantir-python-sdk](https://github.com/palantir/palantir-python-sdk), so Python must be installed on the system.

--- a/changelog/@unreleased/pr-9.v2.yml
+++ b/changelog/@unreleased/pr-9.v2.yml
@@ -1,0 +1,10 @@
+type: improvement
+improvement:
+  description: |-
+    Use arrow for read_table and write_table
+
+    For read_table, we're seeing performance issues for large datasets with specific types (e.g. dates). Converting types in python from arrow to pandas and from pandas to data.frame caused an overhead.
+
+    However, this slightly changes the behavior, for instance missing values in a STRING column are now represented as NA rather than NULL, which allows R to preserve the type. These NA values are not properly handled by reticulate when converting to pandas, so we're also using arrow for writeback.
+  links:
+  - https://github.com/palantir/palantir-r-sdk/pull/9

--- a/man/read_table.Rd
+++ b/man/read_table.Rd
@@ -14,8 +14,8 @@ The Foundry dataset must be tabular, i.e. have a schema.}
 A data.table
 }
 \description{
-Note that the variable classes may not match exactly the Foundry column types.
-A STRING column with NULL values will be cast as a list variable to properly
-capture NULL values and empty strings.
+Note that types may not match exactly the Foundry column types.
+See https://arrow.apache.org/docs/r/articles/arrow.html for details on type conversions
+from an arrow Table to a data.frame.
 For more advanced usage, use `read_table_arrow`.
 }

--- a/man/read_table_arrow.Rd
+++ b/man/read_table_arrow.Rd
@@ -21,7 +21,7 @@ The `arrow` library must be loaded prior to calling this function.
 library(arrow)
 library(dplyr)
 
-df <- read_table.arrow("/path/to/dataset")
+df <- read_table_arrow("/path/to/dataset")
     \%>\% select("column" == "value")
     \%>\% collect()
 }

--- a/man/write_table.Rd
+++ b/man/write_table.Rd
@@ -7,10 +7,12 @@
 write_table(data, dataset)
 }
 \arguments{
-\item{data}{A data.frame.}
+\item{data}{A data.frame or an arrow Table.}
 
 \item{dataset}{A Dataset or a character string representing the RID or dataset path.}
 }
 \description{
-Writes a data.frame to a Foundry dataset.
+Note that types may not be exactly preserved and all types are not supported.
+See https://arrow.apache.org/docs/r/articles/arrow.html for details on type conversions
+from a data.frame to an arrow Table. Use arrow::arrow_table to use more granular types.
 }


### PR DESCRIPTION
For read_table, we're seeing performance issues for large datasets with specific types (e.g. dates). Converting types in python from arrow to pandas and from pandas to data.frame caused an overhead.

However, this slightly changes the behavior, for instance missing values in a STRING column are now represented as NA rather than NULL, which allows R to preserve the type. These NA values are not properly handled by reticulate when converting to pandas, so we're also using arrow for writeback.