### PR TITLE
Copy dataframe to ensure arrow metadata is properly set

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: palantir
 Title: Interface to Palantir
-Version: 0.4.0
+Version: 0.5.0
 Authors@R:
     c(person(given = "Alexandre",
              family = "Guinaudeau",

--- a/R/datasets.R
+++ b/R/datasets.R
@@ -31,7 +31,8 @@ NULL
 #'
 #' @export
 read_table <- function(dataset, branch = NULL, transaction = NULL) {
-  read_table_arrow(dataset, branch = branch, transaction = transaction)$to_data_frame()
+  df <- read_table_arrow(dataset, branch = branch, transaction = transaction)$to_data_frame()
+  head(df, n=nrow(df))
 }
 
 #' Reads a tabular Foundry dataset as an arrow Table.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This SDK is incubating and subject to change.
 Install the library from Github:
 ```R
 install.packages("remotes")
-remotes::install_github("https://github.com/palantir/palantir-r-sdk", ref = "0.4.0")
+remotes::install_github("https://github.com/palantir/palantir-r-sdk", ref = "0.5.0")
 ```
 
 This library relies on [palantir-python-sdk](https://github.com/palantir/palantir-python-sdk), so Python must be installed on the system.

--- a/changelog/@unreleased/pr-15.v2.yml
+++ b/changelog/@unreleased/pr-15.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Copy dataframe to ensure arrow metadata is properly set
+  links:
+  - https://github.com/palantir/palantir-r-sdk/pull/15


### PR DESCRIPTION
We've seen issues when attempting to write back a dataframe read from Foundry using `palantir::read_table`. This seems to be caused by a bug in arrow which doesn't set the metadata properly: simply copying the dataframe resolves the issue.