### PR TITLE
Validate CRAN package on R-devel

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,11 +21,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'macOS-latest', 'windows-latest', 'ubuntu-latest' ]
-        r: [ '3.6', '4.1' ]
+        r: [ '3.6', '4.1', 'devel' ]
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      _R_CHECK_RD_VALIDATE_RD2HTML_: TRUE
 
     steps:
       - uses: actions/checkout@v2
@@ -41,6 +42,7 @@ jobs:
 
       - uses: r-lib/actions/check-r-package@v2
         with:
+          args: '"--as-cran"'
           error-on: '"note"'
 
   lint:
@@ -52,7 +54,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'macOS-latest', 'windows-latest', 'ubuntu-latest' ]
-        r: [ '3.6', '4.1' ]
+        r: [ '3.6', '4.1', 'devel' ]
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -71,3 +73,6 @@ jobs:
       - name: Lint
         run: lintr::lint_package()
         shell: Rscript {0}
+  
+  all-jobs:
+    needs: [ 'check', 'lint' ]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,12 +70,8 @@ jobs:
 
       - uses: r-lib/actions/check-r-package@v2
         with:
-          args: 'c("--as-cran", "--no-codoc", "--no-examples", "--no-tests", "--no-vignettes", "--no-build-vignettes", "--ignore-vignettes", "--no-install")'
-          build_args: 'c("--no-build-vignettes")'
+          args: '"--as-cran"'
           error-on: '"note"'
-        env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
-          _R_CHECK_CRAN_INCOMING_: false
 
   lint:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,10 +26,9 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
-      _R_CHECK_RD_VALIDATE_RD2HTML_: TRUE
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -42,8 +41,41 @@ jobs:
 
       - uses: r-lib/actions/check-r-package@v2
         with:
-          args: '"--as-cran"'
           error-on: '"note"'
+
+  html5-check:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: 'devel'
+          http-user-agent: 'release'
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          dependencies: 'character()'
+
+      - name: Install pdflatex
+        run: sudo apt-get install texlive-latex-base texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra
+
+      - name: Install tidy
+        run: sudo apt install tidy
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          args: 'c("--as-cran", "--no-codoc", "--no-examples", "--no-tests", "--no-vignettes", "--no-build-vignettes", "--ignore-vignettes", "--no-install")'
+          build_args: 'c("--no-build-vignettes")'
+          error-on: '"note"'
+        env:
+          _R_CHECK_CRAN_INCOMING_REMOTE_: false
+          _R_CHECK_CRAN_INCOMING_: false
 
   lint:
     runs-on: ${{ matrix.os }}
@@ -59,7 +91,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -79,7 +111,7 @@ jobs:
 
     name: All Jobs
 
-    needs: [ 'check', 'lint' ]
+    needs: [ 'check', 'html5-check', 'lint' ]
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,13 +54,11 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: 'devel'
-          http-user-agent: 'release'
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
-          dependencies: 'character()'
+          extra-packages: rcmdcheck
 
       - name: Install pdflatex
         run: sudo apt-get install texlive-latex-base texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,7 +82,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'macOS-latest', 'windows-latest', 'ubuntu-latest' ]
-        r: [ '3.6', '4.1', 'devel' ]
+        r: [ '3.6', '4.1' ]
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,4 +75,15 @@ jobs:
         shell: Rscript {0}
   
   all-jobs:
+    runs-on: ubuntu-latest
+
+    name: All Jobs
+
     needs: [ 'check', 'lint' ]
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+    - name: Workflow succeeded
+      run: echo "All jobs succeeded"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Maintainer: Alexandre Guinaudeau <aguinaudeau@palantir.com>
 Description: Interface to Palantir Foundry.
 Encoding: UTF-8
 License: Apache License 2.0 | file LICENSE
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Depends: 
     R (>= 3.5.0)
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: foundry
 Title: Interface to Palantir Foundry
-Version: 0.6.0
+Version: 0.7.0
 Authors@R:
     c(person(given = "Alexandre",
              family = "Guinaudeau",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Maintainer: Alexandre Guinaudeau <aguinaudeau@palantir.com>
 Description: Interface to Palantir Foundry.
 Encoding: UTF-8
 License: Apache License 2.0 | file LICENSE
-RoxygenNote: 7.2.3
+RoxygenNote: 7.2.1
 Depends: 
     R (>= 3.5.0)
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,3 +33,4 @@ Collate:
     'schema.R'
     'datasets_api_client.R'
     'datasets.R'
+    'utils.R'

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,21 @@
+#  (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# R 4.2.0 does not consider code in classes created at install time, so the dependency check fails
+# Workaround per https://community.rstudio.com/t/new-r-cmd-check-note-in-r-4-2-0-for-imports-field/143153/2
+#' @keywords internal
+unused <- function() {
+  R6::R6Class
+  jsonlite::toJSON
+}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Install the library from Github:
 ```R
 install.packages("remotes")
-remotes::install_github("https://github.com/palantir/palantir-r-sdk", ref = "0.6.0")
+remotes::install_github("https://github.com/palantir/palantir-r-sdk", ref = "0.7.0")
 ```
 
 ### Configuration

--- a/changelog/@unreleased/pr-18.v2.yml
+++ b/changelog/@unreleased/pr-18.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Validate CRAN package on R-devel
+  links:
+  - https://github.com/palantir/palantir-r-sdk/pull/18


### PR DESCRIPTION
CRAN requires that packages be tested against the latest _develop_ version of R.
R 4.2.0 introduced a breaking change in some checks:
- HTML5 support in documentation is required
- package functions called inside classes aren't detected upon installation