### PR TITLE
Support HTTP scheme

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: foundry
 Title: 'Palantir Foundry' Software Development Kit
-Version: 0.13.0-1
+Version: 0.13.0-2
 Authors@R:
     c(person(given = "Alexandre",
              family = "Guinaudeau",

--- a/R/config.R
+++ b/R/config.R
@@ -85,6 +85,15 @@ should_resolve_aliases <- function() {
 }
 
 #' @keywords internal
+get_scheme <- function() {
+  scheme <- tolower(get_config("scheme", "https"))
+  if (!scheme %in% c("http", "https")) {
+    stop(sprintf("Only http and https schemes are supported, found `%s`", scheme))
+  }
+  scheme
+}
+
+#' @keywords internal
 get_hostname <- function() {
   hostname <- get_config("hostname")
   if (grepl("/", hostname)) {

--- a/R/datasets_api_client.R
+++ b/R/datasets_api_client.R
@@ -237,9 +237,10 @@ DatasetsApiService <- R6::R6Class(
 
 #' @keywords internal
 get_datasets_client <- function() {
+  scheme <- get_scheme()
   hostname <- get_hostname()
   context_path <- get_config("datasets_context_path", "/api/v1/datasets")
-  base_path <- paste0("https://", hostname, context_path)
+  base_path <- paste0(scheme, "://", hostname, context_path)
   DatasetsApiService$new(
     base_path = base_path,
     auth_token = get_config("token"))

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ install.packages("foundry")
 Alternatively, install the latest development version from Github:
 ```R
 install.packages("remotes")
-remotes::install_github("https://github.com/palantir/palantir-r-sdk", ref = "0.13.0-rc1")
+remotes::install_github("https://github.com/palantir/palantir-r-sdk", ref = "0.13.0-rc2")
 ```
 
 ### Configuration

--- a/changelog/@unreleased/pr-26.v2.yml
+++ b/changelog/@unreleased/pr-26.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Support HTTP scheme for localhost communication
+  links:
+  - https://github.com/palantir/palantir-r-sdk/pull/26

--- a/tests/testthat/test-datasets_api_client.R
+++ b/tests/testthat/test-datasets_api_client.R
@@ -12,10 +12,11 @@ test_that("default datasets client has expected path", {
 test_that("datasets client path can be overriden", {
   withr::with_envvar(
     list(
+      FOUNDRY_SCHEME = "http",
       FOUNDRY_HOSTNAME = "localhost:8080",
       FOUNDRY_DATASETS_CONTEXT_PATH = "/internal-api",
       FOUNDRY_TOKEN = "token"), {
     datasets_client <- get_datasets_client()
-    expect_equal(datasets_client$api_client$base_path, "https://localhost:8080/internal-api")
+    expect_equal(datasets_client$api_client$base_path, "http://localhost:8080/internal-api")
   })
 })


### PR DESCRIPTION
When running internally and communicating with localhost, it can be acceptable to use the HTTP scheme. Adding back support in case we need it.