### PR TITLE
Load configurations at runtime

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -94,7 +94,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: lintr
+          extra-packages: any::lintr, local::.
+          needs: lint
 
       - name: Lint
         run: lintr::lint_package()

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: foundry
 Title: 'Palantir Foundry' Software Development Kit
-Version: 0.13.0-2
+Version: 0.13.0-3
 Authors@R:
     c(person(given = "Alexandre",
              family = "Guinaudeau",

--- a/R/api_client.R
+++ b/R/api_client.R
@@ -30,8 +30,8 @@ ApiClient  <- R6::R6Class( # nolint: cyclopcomp_linter
     default_headers = NULL,
     # Access token
     access_token = NULL,
-    # Time Out (seconds). By default, match CURL timeout.
-    timeout = as.numeric(get_config("requests.timeout", 150)),
+    # Time Out (seconds)
+    timeout = NULL,
     # Vector of status codes to retry. By default, match java remoting
     # https://github.com/palantir/conjure-java-runtime/tree/3.12.0#quality-of-service-retry-failover-throttling
     retry_status_codes = c(308, 429, 503),
@@ -42,6 +42,8 @@ ApiClient  <- R6::R6Class( # nolint: cyclopcomp_linter
       self$base_path <- base_path
       self$access_token <- access_token
       self$default_headers["Authorization"] <- sprintf("Bearer %s", access_token)
+      # By default, match CURL timeout
+      self$timeout <- as.numeric(get_config("requests.timeout", 150))
     },
 
     stop_for_status = function(resp) {

--- a/R/config.R
+++ b/R/config.R
@@ -13,7 +13,9 @@
 #  limitations under the License.
 
 #' @keywords internal
-DEFAULT_CONFIG_DIR <- file.path(path.expand("~"), ".foundry")
+get_default_config_dir <- function() {
+  file.path(path.expand("~"), ".foundry")
+}
 
 #' @keywords internal
 ALIASES_FILE <- "aliases.yml"
@@ -67,7 +69,7 @@ get_config_from_yaml_file <- function(name, filename, default = NULL) {
 
 #' @keywords internal
 get_yaml_config_file <- function(filename) {
-  file.path(get_config("config_dir", DEFAULT_CONFIG_DIR), filename)
+  file.path(get_config("config_dir", get_default_config_dir()), filename)
 }
 
 #' @keywords internal

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ install.packages("foundry")
 Alternatively, install the latest development version from Github:
 ```R
 install.packages("remotes")
-remotes::install_github("https://github.com/palantir/palantir-r-sdk", ref = "0.13.0-rc2")
+remotes::install_github("https://github.com/palantir/palantir-r-sdk", ref = "0.13.0-rc3")
 ```
 
 ### Configuration

--- a/changelog/@unreleased/pr-31.v2.yml
+++ b/changelog/@unreleased/pr-31.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Load configurations at runtime
+  links:
+  - https://github.com/palantir/palantir-r-sdk/pull/31


### PR DESCRIPTION
2 configurations were loaded when the package was attached instead of being loaded at runtime, causing overrides to be ignored.